### PR TITLE
Issue resolved to update action version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
             default: ''
 
 runs:
-      using: 'node16'
+      using: 'node20'
       main: 'index.js'


### PR DESCRIPTION
I have updated the action file to use node20 since that is the new standard. I see a similar commit was made 2 years ago when node16 was required.